### PR TITLE
Allow operation at arbitrary sample rates

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,13 +1,14 @@
 ### general setup
 ACLOCAL_AMFLAGS = -I m4
+EIGEN3_CFLAGS = @eigen3_cflags@
 if HAS_DEBUG
-AM_CXXFLAGS = -I$(srcdir)/otherlibs/ -fPIC -g -fbounds-check
+AM_CXXFLAGS = -fPIC -g -fbounds-check
 MORE_WARNINGS_CXXFLAGS = -Wall -Werror -Wextra
 else
 if IS_DARWIN
-AM_CXXFLAGS = -I$(srcdir)/otherlibs/ -fPIC -O3 -mtune=native -DNDEBUG
+AM_CXXFLAGS = -fPIC -O3 -mtune=native -DNDEBUG
 else
-AM_CXXFLAGS = -I$(srcdir)/otherlibs/ -fPIC -O3 -march=native -DNDEBUG
+AM_CXXFLAGS = -fPIC -O3 -march=native -DNDEBUG
 endif
 MORE_WARNINGS_CXXFLAGS =
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,6 +82,7 @@ libartifastring_a_SOURCES = $(artifastring_h) \
 libartifastring_a_CXXFLAGS = $(AM_CXXFLAGS) \
 	$(MORE_WARNINGS_CXXFLAGS) \
 	$(EIGEN3_CFLAGS)
+# $(SAMPLERATE_CFLAGS)
 artifastring_includedir=$(includedir)/artifastring/
 libmonowav_a_SOURCES = $(monowav_h) \
 	artifastring/monowav.cpp 

--- a/artifastring.pc.in
+++ b/artifastring.pc.in
@@ -7,6 +7,6 @@ Name: Artifastring
 Description: Artifastring ("artificial fast string") is a highly optimized physical simulation of a violin for sound synthesis.
 Requires:
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lartifastring -lm -lfftw3f
+Libs: -L${libdir} -lartifastring -lm -lfftw3f -lsamplerate
 Cflags: -I${includedir}
 

--- a/artifastring/artifastring_instrument.cpp
+++ b/artifastring/artifastring_instrument.cpp
@@ -26,6 +26,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <samplerate.h>
 
 #include <iostream>
@@ -685,7 +686,7 @@ void ArtifastringInstrument::resample_time_data(const float*& time_data,
             };
             
             if (int err = src_simple(&resample_spec, SRC_SINC_BEST_QUALITY, 1 /* channel */))
-                throw new std::string(src_strerror(err));
+                throw new std::runtime_error(src_strerror(err));
             
             // FIXME: Renormalise filter gain when the kernel length changes
             // fft_convolution doesn't normalise, so the factor needed here

--- a/artifastring/artifastring_instrument.cpp
+++ b/artifastring/artifastring_instrument.cpp
@@ -695,7 +695,7 @@ void ArtifastringInstrument::resample_time_data(const float*& time_data,
             // approximation is applied here rather than change the way the
             // Python code works. This should probably be fixed.
             for (int i{0}; i < num_resampled_taps; i++)
-                time_data_cache[k][i] /= sr_ratio*sr_ratio;
+                time_data_cache[k][i] /= std::max(2.0f, sr_ratio*sr_ratio);
         }
 
         time_data = time_data_cache[k].get();

--- a/artifastring/artifastring_instrument.cpp
+++ b/artifastring/artifastring_instrument.cpp
@@ -78,7 +78,7 @@ ArtifastringInstrument::ArtifastringInstrument(
         const int fs_multiply = FS_MULTIPLICATION_FACTOR[m_instrument_type][st];
 #endif
         artifastringString[st] = new ArtifastringString(m_instrument_type,
-                instrument_number, st, fs_multiply);
+                instrument_number, st, fs_multiply, instrument_sample_rate);
     }
     /*
     m_bridge_force_amplify = BRIDGE_FORCE_AMPLIFY[(int)m_instrument_type]

--- a/artifastring/artifastring_instrument.cpp
+++ b/artifastring/artifastring_instrument.cpp
@@ -695,7 +695,7 @@ void ArtifastringInstrument::resample_time_data(const float*& time_data,
             // approximation is applied here rather than change the way the
             // Python code works. This should probably be fixed.
             for (int i{0}; i < num_resampled_taps; i++)
-                time_data_cache[k][i] /= std::max(2.0f, sr_ratio*sr_ratio);
+                time_data_cache[k][i] /= 2.0*sr_ratio;
         }
 
         time_data = time_data_cache[k].get();

--- a/artifastring/artifastring_instrument.cpp
+++ b/artifastring/artifastring_instrument.cpp
@@ -691,8 +691,8 @@ void ArtifastringInstrument::resample_time_data(const float*& time_data,
             // fft_convolution doesn't normalise, so the factor needed here
             // ends up as sr_ratio^2 approximately. As the normalization takes
             // place in the Python interface by setting a gain factor, this
-            // approximation is applied here rather than make change the
-            // Python interface. This should probably be fixed.
+            // approximation is applied here rather than change the way the
+            // Python code works. This should probably be fixed.
             for (int i{0}; i < num_resampled_taps; i++)
                 time_data_cache[k][i] /= sr_ratio*sr_ratio;
         }

--- a/artifastring/artifastring_instrument.h
+++ b/artifastring/artifastring_instrument.h
@@ -22,6 +22,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 
 #include "artifastring/artifastring_defines.h"
 #include "artifastring/artifastring_constants.h"
@@ -227,11 +228,12 @@ private:
     // map empircally determined response and its transformed sample rate
     // to the cached version at the new sample rate.
     typedef std::pair<const float*, int> resampledTDCacheKey;
-    std::map <resampledTDCacheKey, std::unique_ptr<float[]>> time_data_cache;
+    static std::map <resampledTDCacheKey, std::unique_ptr<float[]>> time_data_cache;
+    static std::mutex cache_mtx;
     
-    void get_resampled_time_data(const float*& time_data,
-                                 int& num_taps,
-                                 const int sample_rate);
+    void resample_time_data(const float*& time_data,
+                            int& num_taps,
+                            const int sample_rate);
 
 
 };

--- a/artifastring/artifastring_instrument.h
+++ b/artifastring/artifastring_instrument.h
@@ -20,6 +20,9 @@
 #ifndef ARTIFASTRING_INSTRUMENT_H
 #define ARTIFASTRING_INSTRUMENT_H
 
+#include <map>
+#include <memory>
+
 #include "artifastring/artifastring_defines.h"
 #include "artifastring/artifastring_constants.h"
 #include "artifastring/fft_convolution.h"
@@ -220,8 +223,17 @@ private:
 
     float m_bridge_force_amplify;
     float m_bow_force_amplify;
+    
+    // map empircally determined response and its transformed sample rate
+    // to the cached version at the new sample rate.
+    typedef std::pair<const float*, int> resampledTDCacheKey;
+    std::map <resampledTDCacheKey, std::unique_ptr<float[]>> time_data_cache;
+    
+    void get_resampled_time_data(const float*& time_data,
+                                 int& num_taps,
+                                 const int sample_rate);
+
 
 };
 
 #endif
-

--- a/artifastring/artifastring_instrument.h
+++ b/artifastring/artifastring_instrument.h
@@ -41,7 +41,9 @@ public:
      * See \ref InstrumentType
      */
     ArtifastringInstrument(InstrumentType instrument_type=Violin,
-                           int instrument_number=0);
+                           int instrument_number=0,
+                           const int instrument_sample_rate=ARTIFASTRING_INSTRUMENT_SAMPLE_RATE
+                          );
     /// \brief Destructor; nothing special
     ~ArtifastringInstrument();
     /// \brief Stops all movement

--- a/artifastring/artifastring_string.cpp
+++ b/artifastring/artifastring_string.cpp
@@ -52,7 +52,10 @@ using namespace std;
 
 ArtifastringString::ArtifastringString(InstrumentType which_instrument,
                                        int instrument_number, int string_number,
-                                       int fs_multiplication_factor)
+                                       int fs_multiplication_factor,
+				       int instrument_sample_rate
+      				)
+: instrument_sr { instrument_sample_rate }
 {
     //
     //_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
@@ -63,7 +66,7 @@ ArtifastringString::ArtifastringString(InstrumentType which_instrument,
     _mm_setcsr( _mm_getcsr() | 0x8040 );
 #endif
     fs_multiplier = fs_multiplication_factor;
-    fs = fs_multiplier * ARTIFASTRING_INSTRUMENT_SAMPLE_RATE;
+    fs = fs_multiplier * instrument_sr;
     dt = 1.0f / fs;
     //printf("fs: %i\tmult: %i\n", fs, fs_multiplier);
 

--- a/artifastring/artifastring_string.cpp
+++ b/artifastring/artifastring_string.cpp
@@ -53,9 +53,8 @@ using namespace std;
 ArtifastringString::ArtifastringString(InstrumentType which_instrument,
                                        int instrument_number, int string_number,
                                        int fs_multiplication_factor,
-				       int instrument_sample_rate
-      				)
-: instrument_sr { instrument_sample_rate }
+                                       int instrument_sample_rate
+                                      )
 {
     //
     //_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
@@ -66,7 +65,7 @@ ArtifastringString::ArtifastringString(InstrumentType which_instrument,
     _mm_setcsr( _mm_getcsr() | 0x8040 );
 #endif
     fs_multiplier = fs_multiplication_factor;
-    fs = fs_multiplier * instrument_sr;
+    fs = fs_multiplier * instrument_sample_rate;
     dt = 1.0f / fs;
     //printf("fs: %i\tmult: %i\n", fs, fs_multiplier);
 

--- a/artifastring/artifastring_string.h
+++ b/artifastring/artifastring_string.h
@@ -212,10 +212,7 @@ public:
 
     void string_release();
 
-protected:
-    // Samle rate of this string
-    const int instrument_sr;
-    
+protected:    
     // physical constants
     String_Physical pc;
 

--- a/artifastring/artifastring_string.h
+++ b/artifastring/artifastring_string.h
@@ -122,10 +122,13 @@ public:
      * @param[in] fs_multiplication_factor This sets the sampling
      * rate of the string by multiplying the base instrument
      * sampling rate.
+     * @param[in] instruemnt_sample_rate The sample rate used for this
+     * string, defaulting to the vaule defined in artifastring_defines.h
      */
     ArtifastringString(InstrumentType which_instrument,
                        int instrument_number, int string_number,
-                       int fs_multiplication_factor);
+                       int fs_multiplication_factor,
+                       const int instrument_sample_rate = ARTIFASTRING_INSTRUMENT_SAMPLE_RATE);
     /// \brief Destructor; nothing special
     ~ArtifastringString();
     /// \brief Stops all movement
@@ -210,6 +213,9 @@ public:
     void string_release();
 
 protected:
+    // Samle rate of this string
+    const int instrument_sr;
+    
     // physical constants
     String_Physical pc;
 

--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,7 @@ AC_LANG([C++])
 AC_CHECK_LIB(stdc++, main,, AC_MSG_ERROR(requires libstdc++))
 AC_CHECK_LIB(m, main,, AC_MSG_ERROR(requires libm (math)))
 AC_CHECK_LIB(fftw3f, main,, AC_MSG_ERROR(requires libfftw3))
+AC_CHECK_LIB(samplerate, src_simple,, AC_MSG_ERROR(requires libsamplerate))
 
 AC_ARG_ENABLE([debug],
   [AS_HELP_STRING(--enable-debug,[Compile with debug support])],
@@ -34,8 +35,8 @@ AM_CONDITIONAL([HAS_DEBUG], [test "x$enable_debug" != xno])
 AC_ARG_WITH([eigen],
   [AS_HELP_STRING(--with-eigen=<path>,
     [Specify path to eigen headers. Default is /usr/include/eigen3])],
-  [echo eigen arg $with_eigen],
-  [echo with-eigen not used. ; with_eigen=default])
+  [],
+  [with_eigen=default])
   
 EIGEN3_CFLAGS=/usr/include/eigen3
 AS_IF([test "x${with_eigen}" = xno], [AC_MSG_WARN(m4_normalize(
@@ -49,8 +50,6 @@ AS_IF([test "x${with_eigen}" = xno], [AC_MSG_WARN(m4_normalize(
       [test "x${with_eigen}" = xdefault], [],
       [EIGEN3_CFLAGS=${with_eigen}])
 
-      echo $with_eigen $EIGEN3_CFLAGS
-      
 AC_CHECK_HEADER(${EIGEN3_CFLAGS}/Eigen/Core,
   [AC_SUBST([eigen3_cflags], ["-I${EIGEN3_CFLAGS}"])],
   [AC_MSG_ERROR([I looked for Eigen/Core in ${EIGEN3_CFLAGS} and failed to find it])],
@@ -70,6 +69,8 @@ AS_IF([test "x$with_swig" != xno],
   AX_SWIG_ENABLE_CXX
   AX_SWIG_PYTHON
   ], [])
+
+#PKG_CHECK_MODULES(SAMPLERATE, samplerate >= 0.1)
 
 
 ### play nice with other fftw users

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_PROG_CXX
 AC_PROG_LIBTOOL
 AC_HEADER_STDC
 
-#AC_LANG([C++])
+AC_LANG([C++])
 
 AC_CHECK_LIB(stdc++, main,, AC_MSG_ERROR(requires libstdc++))
 AC_CHECK_LIB(m, main,, AC_MSG_ERROR(requires libm (math)))
@@ -31,6 +31,30 @@ AC_ARG_ENABLE([debug],
   [enable_debug="no"])
 AM_CONDITIONAL([HAS_DEBUG], [test "x$enable_debug" != xno])
 
+AC_ARG_WITH([eigen],
+  [AS_HELP_STRING(--with-eigen=<path>,
+    [Specify path to eigen headers. Default is /usr/include/eigen3])],
+  [echo eigen arg $with_eigen],
+  [echo with-eigen not used. ; with_eigen=default])
+  
+EIGEN3_CFLAGS=/usr/include/eigen3
+AS_IF([test "x${with_eigen}" = xno], [AC_MSG_WARN(m4_normalize(
+        [Artifastring requires Eigen. The --with-eigen flag allows you to
+         specify the path to the Eigen headers, not to despense with them.
+         Configuration will continue, checking the default location for
+         the Eigen headers, namely ${EIGEN3_CFLAGS}]))],
+      [test "x${with_eigen}" = xyes], [AC_MSG_WARN(m4_normalize(
+        [Using --with-eigen without an argument is just the default behaviour.
+         This option only makes sense when you specify the Eigen include path]))],
+      [test "x${with_eigen}" = xdefault], [],
+      [EIGEN3_CFLAGS=${with_eigen}])
+
+      echo $with_eigen $EIGEN3_CFLAGS
+      
+AC_CHECK_HEADER(${EIGEN3_CFLAGS}/Eigen/Core,
+  [AC_SUBST([eigen3_cflags], ["-I${EIGEN3_CFLAGS}"])],
+  [AC_MSG_ERROR([I looked for Eigen/Core in ${EIGEN3_CFLAGS} and failed to find it])],
+  [AC_INCLUDES_DEFAULT])
 
 ### swig stuff
 AC_ARG_WITH(swig,

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([Makefile artifastring.pc monowav.pc doc/doxyfile])
 
 AC_PREREQ([2.59])
-AM_INIT_AUTOMAKE([1.10 no-define foreign -Wall -Werror])
+AM_INIT_AUTOMAKE([1.10 subdir-objects no-define foreign -Wall -Werror])
 AM_PROG_AR
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,34 @@ AC_CHECK_LIB(stdc++, main,, AC_MSG_ERROR(requires libstdc++))
 AC_CHECK_LIB(m, main,, AC_MSG_ERROR(requires libm (math)))
 AC_CHECK_LIB(fftw3f, main,, AC_MSG_ERROR(requires libfftw3))
 AC_CHECK_LIB(samplerate, src_simple,, AC_MSG_ERROR(requires libsamplerate))
+# Versions of samplerate earlier than about 0.1.9 didn't allow
+# passing of const float* as the data input. So explicitly check for that.
+AC_COMPILE_IFELSE(
+  [AC_LANG_SOURCE([[
+#include <samplerate.h>
+
+int main()
+{
+  const float* src {nullptr};
+  float* dest {nullptr};
+            
+  SRC_DATA resample_spec {
+    src,     // data in
+    dest,    // data output
+    0L,      // number of input frames
+    0L,      // number of output frames
+    0L,      // place holder (input frames used)
+    0L,      // place holder (number of frames generated)
+    0,       // place holder (end of input)
+    1.0      // output sample rate / input sample rate
+  };
+
+  int err (src_simple(&resample_spec, SRC_SINC_BEST_QUALITY, 1 /* channel */));
+
+  return err;
+}
+]])],, AC_MSG_ERROR([Requires libresample to accept const input data (0.1.9 does)]))
+
 
 AC_ARG_ENABLE([debug],
   [AS_HELP_STRING(--enable-debug,[Compile with debug support])],


### PR DESCRIPTION
These changes permit the creation of an `ArtifastringInstrument` at a user-specified sample rate without compromising normal operation at the default internal rate `ARTIFASTRING_INSTRUMENT_SAMPLE_RATE`. This is achieved by resampling the impulse responses of the various convolution kernels on demand when an optional sample rate parameter differing from the internal one is passed to an `ArtifastringInstrument` constructor.

**Pros**: easier to write apps using this library for use with audio frameworks which specify the sample rate (such as JACK on Mac/Linux) without requiring the audio daemon to run a 44100Hz.

**Cons**: `libsamplerate` is an additional dependency; output normalisation is only approximate and changes slightly with sample rate (see comment at https://github.com/nickbailey/artifastring/blob/master/artifastring/artifastring_instrument.cpp#L690)

As the supplied version of `Eigen` no longer compiles cleanly, I have altered `configure.ac` to use an independently installed version. `configure`ing `--with-eigen=...` can be used to select an alternative source if they aren't in `/usr/include/eigen3`.